### PR TITLE
Add a Jenkinsfile to master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,15 +30,16 @@ pipeline {
             }
         }
         stage('Sonar') {
+            when {
+                expression {return !params.SKIP_SONAR }
+            }
             steps {
                 wrap([$class: 'TimestamperBuildWrapper']) {
                     configFileProvider([
                         configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig1427876196924', variable: 'TOOLCHAIN'),
                         configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1377688925713', variable: 'MAVEN_SETTINGS')]) {
-                            if (!SKIP_SONAR) {
-                                withSonarQubeEnv {
-                                    sh 'mvn $SONAR_GOAL -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=$BUILD_TYPE -Dmirror-integration=false -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_AUTH_TOKEN -Dsonar.scm.disabled=true'
-                                }
+                            withSonarQubeEnv {
+                                sh 'mvn $SONAR_GOAL -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=$BUILD_TYPE -Dmirror-integration=false -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_AUTH_TOKEN -Dsonar.scm.disabled=true'
                             }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,11 +16,11 @@ pipeline {
         jdk 'Oracle JDK 8' 
     }
 	 
-    wrap([$class: 'TimestamperBuildWrapper']) {
-        configFileProvider([
-            configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig1427876196924', variable: 'TOOLCHAIN'),
-            configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1377688925713', variable: 'MAVEN_SETTINGS')]) {
-                stages { 
+    stages { 
+        wrap([$class: 'TimestamperBuildWrapper']) {
+            configFileProvider([
+                configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig1427876196924', variable: 'TOOLCHAIN'),
+                configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1377688925713', variable: 'MAVEN_SETTINGS')]) {
                     stage('Build') { 
                         steps {
                             sh 'mvn clean verify -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=$BUILD_TYPE'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,86 @@
+// Tell Jenkins how to build projects from this repository
+pipeline {
+	agent any
+	parameters {
+		booleanParam(defaultValue: true, description: '''This parameter is used to allow not to execute Sonar analysis. It is safe to always make this true, as the Sonar-trigger job will trigger this job without the SKIP_SONAR parameter set daily.''', name: 'SKIP_SONAR'),
+        choice(choices: ['ci', 'integration', 'release'], description: '', name: 'BUILD_TYPE')
+	}
+
+    // Keep only the last 15 builds
+	options {
+		buildDiscarder(logRotator(numToKeepStr: '20'))
+	}
+	
+	tools { 
+        maven 'Maven 3.3.9' 
+        jdk 'Oracle JDK 8' 
+    }
+	 
+    wrap([$class: 'TimestamperBuildWrapper']) {
+        configFileProvider([
+            configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig1427876196924', variable: 'TOOLCHAIN'),
+            configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1377688925713', variable: 'MAVEN_SETTINGS')]) {
+                stages { 
+                    stage('Build') { 
+                        steps {
+                            sh 'mvn clean verify -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=$BUILD_TYPE'
+                            sh './releng/massif.commandevaluation.server-package/prepareMatlabServerPackage.sh'
+                        }
+		            }
+                    stage('Sonar') {
+                        steps {
+                            if (!$SKIP_SONAR) {
+                                withSonarQubeEnv {
+                                    sh 'mvn $SONAR_GOAL -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=$BUILD_TYPE -Dmirror-integration=false -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_AUTH_TOKEN -Dsonar.scm.disabled=true'
+                                }
+                            }
+                        }
+                    }
+                    stage('Deployment') {
+                        sh '''  if [ -d "massif-install-artifacts" ]; then
+                                    rm -fr massif-install-artifacts
+                                fi
+                                mkdir massif-install-artifacts
+                                mkdir massif-install-artifacts/${BUILD_TYPE}
+                                mkdir massif-install-artifacts/${BUILD_TYPE}/site
+
+                                cp -R releng/hu.bme.mit.massif.site/target/repository/* massif-install-artifacts/${BUILD_TYPE}/site/
+                                cp releng/massif.commandevaluation.server-package/massif.commandevaluation.server.zip massif-install-artifacts/${BUILD_TYPE}/massif.commandevaluation.server-${BUILD_TYPE}_${BUILD_ID}.zip'''
+                        sshagent(['24f0908d-7662-4e93-80cc-1143b7f92ff1']) {
+                            // some block
+                            sh 'scp massif-install-artifacts/* jenkins@static.incquerylabs.com:projects/massif/massif-artifacts -P 45678'
+                            sh 'ssh jenkins@static.incquerylabs.com -p 45678 /home/jenkins/static/projects/massif/massif-artifacts.sh'
+                        }
+                    }
+                }
+        }
+    }
+    
+    post {
+    	always {
+    		archiveArtifacts 'releng/hu.bme.mit.massif.site/target/repository/**'
+    		archiveArtifacts 'releng/massif.commandevaluation.server-package/massif.commandevaluation.server.zip'
+    	}
+        success {
+            slackSend channel: "viatra-notifications", 
+    			color: "good",
+				message: "Build Successful - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)",
+    			teamDomain: "incquerylabs",
+    			tokenCredentialId: "6ff98023-8c20-4d9c-821a-b769b0ea0fad" 
+        }
+		unstable {
+	   		slackSend channel: "viatra-notifications", 
+    			color: "warning",
+    			message: "Build Unstable - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)",
+    			teamDomain: "incquerylabs",
+    			tokenCredentialId: "6ff98023-8c20-4d9c-821a-b769b0ea0fad"
+    	}
+		failure {
+    		slackSend channel: "viatra-notifications", 
+    			color: "danger",
+    			message: "Build Failed - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)",
+    			teamDomain: "incquerylabs",
+    			tokenCredentialId: "6ff98023-8c20-4d9c-821a-b769b0ea0fad"
+		}
+	}
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,14 +65,14 @@ pipeline {
     }
     
     post {
-    	always {
-    		archiveArtifacts 'releng/hu.bme.mit.massif.site/target/repository/**'
-    		archiveArtifacts 'releng/massif.commandevaluation.server-package/massif.commandevaluation.server.zip'
-    	}
+    		always {
+    			archiveArtifacts 'releng/hu.bme.mit.massif.site/target/repository/**'
+    			archiveArtifacts 'releng/massif.commandevaluation.server-package/massif.commandevaluation.server.zip'
+    		}
         success {
             slackSend channel: "viatra-notifications", 
     			color: "good",
-				message: "Build Successful - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)",
+			message: "Build Successful - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)",
     			teamDomain: "incquerylabs",
     			tokenCredentialId: "6ff98023-8c20-4d9c-821a-b769b0ea0fad" 
         }
@@ -82,9 +82,9 @@ pipeline {
     			message: "Build Unstable - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)",
     			teamDomain: "incquerylabs",
     			tokenCredentialId: "6ff98023-8c20-4d9c-821a-b769b0ea0fad"
-    	}
+    		}
 		failure {
-    		slackSend channel: "viatra-notifications", 
+    			slackSend channel: "viatra-notifications", 
     			color: "danger",
     			message: "Build Failed - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)",
     			teamDomain: "incquerylabs",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 pipeline {
 	agent any
 	parameters {
-		booleanParam(defaultValue: true, description: '''This parameter is used to allow not to execute Sonar analysis. It is safe to always make this true, as the Sonar-trigger job will trigger this job without the SKIP_SONAR parameter set daily.''', name: 'SKIP_SONAR'),
+		booleanParam(defaultValue: true, description: '''This parameter is used to allow not to execute Sonar analysis. It is safe to always make this true, as the Sonar-trigger job will trigger this job without the SKIP_SONAR parameter set daily.''', name: 'SKIP_SONAR')
         choice(choices: ['ci', 'integration', 'release'], description: '', name: 'BUILD_TYPE')
 	}
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 	agent any
 	parameters {
 		booleanParam(defaultValue: true, description: '''This parameter is used to allow not to execute Sonar analysis. It is safe to always make this true, as the Sonar-trigger job will trigger this job without the SKIP_SONAR parameter set daily.''', name: 'SKIP_SONAR')
-        choice(choices: ['ci', 'integration', 'release'], description: '', name: 'BUILD_TYPE')
+        choice(choices: 'ci\nintegration\nrelease', description: '', name: 'BUILD_TYPE')
 	}
 
     // Keep only the last 15 builds

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
                     configFileProvider([
                         configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig1427876196924', variable: 'TOOLCHAIN'),
                         configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1377688925713', variable: 'MAVEN_SETTINGS')]) {
-                            withSonarQubeEnv {
+                            withSonarQubeEnv('IncQuery Labs SonarQube') {
                                 sh 'mvn $SONAR_GOAL -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=$BUILD_TYPE -Dmirror-integration=false -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_AUTH_TOKEN -Dsonar.scm.disabled=true'
                             }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
                     configFileProvider([
                         configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig1427876196924', variable: 'TOOLCHAIN'),
                         configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1377688925713', variable: 'MAVEN_SETTINGS')]) {
-                            sh 'mvn clean verify -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=$BUILD_TYPE'
+                            sh 'mvn clean verify -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=${BUILD_TYPE}'
                             sh './releng/massif.commandevaluation.server-package/prepareMatlabServerPackage.sh'
                         }
                 }
@@ -39,7 +39,7 @@ pipeline {
                         configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig1427876196924', variable: 'TOOLCHAIN'),
                         configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1377688925713', variable: 'MAVEN_SETTINGS')]) {
                             withSonarQubeEnv('IncQuery Labs SonarQube') {
-                                sh 'mvn $SONAR_GOAL -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=$BUILD_TYPE -Dmirror-integration=false -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_AUTH_TOKEN -Dsonar.scm.disabled=true'
+                                sh 'mvn sonar:sonar -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=$BUILD_TYPE -Dmirror-integration=false -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_AUTH_TOKEN -Dsonar.scm.disabled=true'
                             }
                     }
                 }
@@ -51,14 +51,14 @@ pipeline {
                             rm -fr massif-install-artifacts
                         fi
                         mkdir massif-install-artifacts
-                        mkdir massif-install-artifacts/${BUILD_TYPE}
-                        mkdir massif-install-artifacts/${BUILD_TYPE}/site
+                        mkdir massif-install-artifacts/$BUILD_TYPE
+                        mkdir massif-install-artifacts/$BUILD_TYPE/site
 
-                        cp -R releng/hu.bme.mit.massif.site/target/repository/* massif-install-artifacts/${BUILD_TYPE}/site/
-                        cp releng/massif.commandevaluation.server-package/massif.commandevaluation.server.zip massif-install-artifacts/${BUILD_TYPE}/massif.commandevaluation.server-${BUILD_TYPE}_${BUILD_ID}.zip'''
+                        cp -R releng/hu.bme.mit.massif.site/target/repository/* massif-install-artifacts/$BUILD_TYPE/site/
+                        cp releng/massif.commandevaluation.server-package/massif.commandevaluation.server.zip massif-install-artifacts/$BUILD_TYPE/massif.commandevaluation.server-$params.BUILD_TYPE_$BUILD_ID.zip'''
                 sshagent(['24f0908d-7662-4e93-80cc-1143b7f92ff1']) {
-                    sh 'scp massif-install-artifacts/* jenkins@static.incquerylabs.com:projects/massif/massif-artifacts -P 45678'
-                    sh 'ssh jenkins@static.incquerylabs.com -p 45678 /home/jenkins/static/projects/massif/massif-artifacts.sh'
+                    sh 'scp -o StrictHostKeyChecking=no -P 45678 -r massif-install-artifacts/* jenkins@static.incquerylabs.com:/home/jenkins/static/projects/massif/massif-artifacts'
+                    sh 'ssh -o StrictHostKeyChecking=no -p 45678 jenkins@static.incquerylabs.com /home/jenkins/static/projects/massif/massif-artifacts.sh'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,45 +18,47 @@ pipeline {
 	 
     stages { 
         stage('Build') { 
-            wrap([$class: 'TimestamperBuildWrapper']) {
-                configFileProvider([
-                    configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig1427876196924', variable: 'TOOLCHAIN'),
-                    configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1377688925713', variable: 'MAVEN_SETTINGS')]) {
-                        steps {
+            steps {
+                wrap([$class: 'TimestamperBuildWrapper']) {
+                    configFileProvider([
+                        configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig1427876196924', variable: 'TOOLCHAIN'),
+                        configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1377688925713', variable: 'MAVEN_SETTINGS')]) {
                             sh 'mvn clean verify -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=$BUILD_TYPE'
                             sh './releng/massif.commandevaluation.server-package/prepareMatlabServerPackage.sh'
                         }
-		            }
                 }
+            }
         }
         stage('Sonar') {
-            wrap([$class: 'TimestamperBuildWrapper']) {
-                configFileProvider([
-                    configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig1427876196924', variable: 'TOOLCHAIN'),
-                    configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1377688925713', variable: 'MAVEN_SETTINGS')]) {
-                        steps {
+            steps {
+                wrap([$class: 'TimestamperBuildWrapper']) {
+                    configFileProvider([
+                        configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig1427876196924', variable: 'TOOLCHAIN'),
+                        configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1377688925713', variable: 'MAVEN_SETTINGS')]) {
                             if (!$SKIP_SONAR) {
                                 withSonarQubeEnv {
                                     sh 'mvn $SONAR_GOAL -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=$BUILD_TYPE -Dmirror-integration=false -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_AUTH_TOKEN -Dsonar.scm.disabled=true'
                                 }
                             }
-                        }
+                    }
                 }
             }
         }
         stage('Deployment') {
-            sh '''  if [ -d "massif-install-artifacts" ]; then
-                        rm -fr massif-install-artifacts
-                    fi
-                    mkdir massif-install-artifacts
-                    mkdir massif-install-artifacts/${BUILD_TYPE}
-                    mkdir massif-install-artifacts/${BUILD_TYPE}/site
+            steps{
+                sh '''  if [ -d "massif-install-artifacts" ]; then
+                            rm -fr massif-install-artifacts
+                        fi
+                        mkdir massif-install-artifacts
+                        mkdir massif-install-artifacts/${BUILD_TYPE}
+                        mkdir massif-install-artifacts/${BUILD_TYPE}/site
 
-                    cp -R releng/hu.bme.mit.massif.site/target/repository/* massif-install-artifacts/${BUILD_TYPE}/site/
-                    cp releng/massif.commandevaluation.server-package/massif.commandevaluation.server.zip massif-install-artifacts/${BUILD_TYPE}/massif.commandevaluation.server-${BUILD_TYPE}_${BUILD_ID}.zip'''
-            sshagent(['24f0908d-7662-4e93-80cc-1143b7f92ff1']) {
-                sh 'scp massif-install-artifacts/* jenkins@static.incquerylabs.com:projects/massif/massif-artifacts -P 45678'
-                sh 'ssh jenkins@static.incquerylabs.com -p 45678 /home/jenkins/static/projects/massif/massif-artifacts.sh'
+                        cp -R releng/hu.bme.mit.massif.site/target/repository/* massif-install-artifacts/${BUILD_TYPE}/site/
+                        cp releng/massif.commandevaluation.server-package/massif.commandevaluation.server.zip massif-install-artifacts/${BUILD_TYPE}/massif.commandevaluation.server-${BUILD_TYPE}_${BUILD_ID}.zip'''
+                sshagent(['24f0908d-7662-4e93-80cc-1143b7f92ff1']) {
+                    sh 'scp massif-install-artifacts/* jenkins@static.incquerylabs.com:projects/massif/massif-artifacts -P 45678'
+                    sh 'ssh jenkins@static.incquerylabs.com -p 45678 /home/jenkins/static/projects/massif/massif-artifacts.sh'
+                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
                     configFileProvider([
                         configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenToolchainsConfig1427876196924', variable: 'TOOLCHAIN'),
                         configFile(fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1377688925713', variable: 'MAVEN_SETTINGS')]) {
-                            if (!$SKIP_SONAR) {
+                            if (!SKIP_SONAR) {
                                 withSonarQubeEnv {
                                     sh 'mvn $SONAR_GOAL -B -t $TOOLCHAIN -s $MAVEN_SETTINGS -f releng/hu.bme.mit.massif.parent/pom.xml -Dmaven.repo.local=$WORKSPACE/.repository -DBUILD_TYPE=$BUILD_TYPE -Dmirror-integration=false -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_AUTH_TOKEN -Dsonar.scm.disabled=true'
                                 }


### PR DESCRIPTION
In order to utilize the new capabilities of Jenkins, Massif should rely on a Jenkinsfile to execute the build. @abelhegedus, what do you think about this version?