### PR TITLE
#206 Pick the right cell when parsing bus signals

### DIFF
--- a/plugins/hu.bme.mit.massif.simulink.api/src/hu/bme/mit/massif/simulink/api/adapter/block/PortAdapter.java
+++ b/plugins/hu.bme.mit.massif.simulink.api/src/hu/bme/mit/massif/simulink/api/adapter/block/PortAdapter.java
@@ -1,12 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2010-2013, Embraer S.A., Budapest University of Technology and Economics
+ * Copyright (c) 2010-2021, Embraer S.A., Budapest University of Technology and Economics,
+ * Alessio Di Sandro
  * All rights reserved. This program and the accompanying materials 
  * are made available under the terms of the Eclipse Public License v1.0 
  * which accompanies this distribution, and is available at 
  * http://www.eclipse.org/legal/epl-v10.html 
  *
  * Contributors: 
- *     Marton Bur, Abel Hegedus, Akos Horvath - initial API and implementation 
+ *     Marton Bur, Abel Hegedus, Akos Horvath - initial API and implementation
+ *     Alessio Di Sandro - Fix issue #206
  *******************************************************************************/
 package hu.bme.mit.massif.simulink.api.adapter.block;
 
@@ -104,7 +106,7 @@ public abstract class PortAdapter extends DefaultBlockAdapter {
         busSignal.setSignalName(signalName);
         
         if (isBus) {
-            List<IVisitableMatlabData> busSignals = CellMatlabData.getCellMatlabDataData(CellMatlabData.getCellMatlabDataData(signalCell.getData(0)).get(5));
+            List<IVisitableMatlabData> busSignals = CellMatlabData.getCellMatlabDataData(signalCell.getData(5));
             for (IVisitableMatlabData signal : busSignals) {
                 String childSignalName = MatlabString.getMatlabStringData(CellMatlabData.asCellMatlabData(signal).getData(0));
                 busSignal.getSignalsInBus().add(processBusObject(childSignalName,commandFactory));


### PR DESCRIPTION
This fixes the `IndexOutOfBoundsException` in `PortAdapter` when parsing bus signals.