### PR TITLE
#194 Skip BlockKeywords block property

### DIFF
--- a/plugins/hu.bme.mit.massif.simulink.api/scripts/massif_functions.m
+++ b/plugins/hu.bme.mit.massif.simulink.api/scripts/massif_functions.m
@@ -81,13 +81,15 @@ function s = get_all_block_parameters(blockId)
 %    * MaskObject
 %    * Binding (Simulink.HMI.SignalSpecification object)
 %    * MaskWSVariables (mpc object)
+%    * BlockKeywords
 
 s=struct();
 TmpObjParams=get_param(blockId,'ObjectParameters');
 names=fieldnames(TmpObjParams);
 for i = 1:numel(names)
     if strcmpi(names{i},'Capabilities') == 0 && strcmpi(names{i},'MaskObject') == 0 && ...
-            strcmpi(names{i},'Binding') == 0 && strcmpi(names{i},'MaskWSVariables') == 0
+            strcmpi(names{i},'Binding') == 0 && strcmpi(names{i},'MaskWSVariables') == 0 && ...
+            strcmpi(names{i},'BlockKeywords') == 0
         TmpParamValue=get_param(blockId,names{i});
         isReadOnly = sum(strcmp(TmpObjParams.(names{i}).Attributes,'read-only'));
         isNeverSave = sum(strcmp(TmpObjParams.(names{i}).Attributes,'never-save'));


### PR DESCRIPTION
I was able to import simulink models (_sldemo_clutch_import.mdl_, _Example_MATLAB.slx_ from the repository) using MATLAB R2021a by skipping the _BlockKeywords_ block property (which will be a _com.mathworks.jmi.types.MLArrayRef_ in Java, that cannot be serialized as stated in https://github.com/viatra/massif/issues/194#issuecomment-505887676) in _massif_functions.m_. The description of BlockKeywords can be found here: https://mathworks.com/help/simulink/slref/common-block-parameters.html